### PR TITLE
Malnick/haproxy plugin

### DIFF
--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -41,14 +41,8 @@ class newrelic_plugins::haproxy (
     content => template('newrelic_plugins/haproxy/newrelic_haproxy_plugin.erb'),
   }
 
-  exec {'newrelic_haproxy_agent_config':
-    command  => '/usr/local/bin/newrelic_haproxy_agent install',
-    require  => Package['bundler','newrelic_plugin','newrelic_haproxy_agent'],
-    creates  => '/etc/newrelic/newrelic_haproxy_agent.yml',
-  }
-
   # Configure the yaml file
-  file { '/etc/newrelic/newrelic/newrelic_haproxy_agent.yml':
+  file { '/etc/newrelic/newrelic_haproxy_agent.yml':
     ensure    => file,
     mode      => '0644',
     content   => template('newrelic_plugins/haproxy/newrelic_haproxy_agent.yml.erb'),

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -14,6 +14,28 @@ class newrelic_plugins::haproxy (
     require   => Package['make'],
   }
 
+  package { 'newrelic_plugin':
+    ensure    => present,
+    provider  => 'gem',
+    require   => Package['make'],
+  }
 
+  package { 'bundler':
+    ensure    => present,
+    provider  => 'gem',
+    require   => Package['make'],
+  }
+
+  exec {'newrelic_haproxy_agent_config':
+    command => '/usr/local/bin/newrelic_haproxy_agent install',
+    require => Package['bundler','newrelic_plugin','newrelic_haproxy_agent'],
+    create  => '/etc/newrelic/newrelic_haproxy_agent.yml',
+  }
+
+  service { 'newrelic_haproxy_agent':
+    ensure    => running,
+    start     => '/usr/local/bin/newrelic_haproxy_agent run',
+    subscribe => Exec['newrelic_haproxy_agent_config'],
+  }
 
 }

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -26,6 +26,12 @@ class newrelic_plugins::haproxy (
     require   => Package['make'],
   }
 
+  file { 'newrelic_haproxy_agent_init':
+    ensure  => file,
+    path    => '/etc/init.d/newrelic_haproxy_agent',
+    content => template('haproxy/newrelic_haproxy_agent.erb'),
+  }
+
   exec {'newrelic_haproxy_agent_config':
     command  => '/usr/local/bin/newrelic_haproxy_agent install',
     require  => Package['bundler','newrelic_plugin','newrelic_haproxy_agent'],
@@ -34,8 +40,8 @@ class newrelic_plugins::haproxy (
 
   service { 'newrelic_haproxy_agent':
     ensure    => running,
-    start     => '/usr/local/bin/newrelic_haproxy_agent run',
-    subscribe => Exec['newrelic_haproxy_agent_config'],
+    enable    => true,
+    subscribe => File['newrelic_haproxy_agent_init'], 
   }
 
 }

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -30,7 +30,7 @@ class newrelic_plugins::haproxy (
     ensure  => file,
     path    => '/etc/init.d/newrelic_haproxy_plugin',
     mode    => '0755',
-    user    => 'root',
+    owner   => 'root',
     group   => 'root',
     content => template('newrelic_plugins/haproxy/newrelic_haproxy_plugin.erb'),
   }

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -17,13 +17,13 @@ class newrelic_plugins::haproxy (
   package { 'newrelic_haproxy_agent':
     ensure    => present,
     provider  => 'gem',
-    require   => Package['make'],
+    require   => Package['make','bundler'],
   }
 
   package { 'newrelic_plugin':
     ensure    => present,
     provider  => 'gem',
-    require   => Package['make'],
+    require   => Package['make','bundler'],
   }
 
   package { 'bundler':
@@ -41,11 +41,23 @@ class newrelic_plugins::haproxy (
     content => template('newrelic_plugins/haproxy/newrelic_haproxy_plugin.erb'),
   }
 
-  # Configure the yaml file
-  file { '/etc/newrelic/newrelic_haproxy_agent.yml':
-    ensure    => file,
-    mode      => '0644',
-    content   => template('newrelic_plugins/haproxy/newrelic_haproxy_agent.yml.erb'),
+  if $base_install {
+    # If base install then install the standard yml, no config
+    exec {'base_install':
+      command => '/usr/local/bin/newrelic_haproxy_agent run',
+      creates => '/etc/newrelic/newrelic_haproxy_agent.yml',
+      require => Package['newrelic_haproxy_agent','newrelic_plugin'],
+    }
+  }
+
+  else {  
+    # Configure the yaml file - requires that haproxy_agents hash is not empty
+    file { '/etc/newrelic/newrelic_haproxy_agent.yml':
+      ensure    => file,
+      mode      => '0644',
+      content   => template('newrelic_plugins/haproxy/newrelic_haproxy_agent.yml.erb'),
+      require => Package['newrelic_haproxy_agent','newrelic_plugin'],
+    }
   }
 
   service { 'newrelic_haproxy_plugin':
@@ -53,5 +65,4 @@ class newrelic_plugins::haproxy (
     enable    => true,
     subscribe => File['newrelic_haproxy_agent_init','/etc/newrelic/newrelic_haproxy_agent.yml'], 
   }
-
 }

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -29,7 +29,7 @@ class newrelic_plugins::haproxy (
   file { 'newrelic_haproxy_agent_init':
     ensure  => file,
     path    => '/etc/init.d/newrelic_haproxy_plugin',
-    content => template('haproxy/newrelic_haproxy_plugin.erb'),
+    content => template('newrelic_plugins/haproxy/newrelic_haproxy_plugin.erb'),
   }
 
   exec {'newrelic_haproxy_agent_config':

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -48,10 +48,16 @@ class newrelic_plugins::haproxy (
   }
 
   # Configure the yaml file
+  file { '/etc/newrelic/newrelic/newrelic_haproxy_agent.yml':
+    ensure    => file,
+    mode      => '0644',
+    content   => template('newrelic_plugins/haproxy/newrelic_haproxy_agent.yml.erb'),
+  }
+
   service { 'newrelic_haproxy_plugin':
     ensure    => running,
     enable    => true,
-    subscribe => File['newrelic_haproxy_agent_init'], 
+    subscribe => File['newrelic_haproxy_agent_init','/etc/newrelic/newrelic/newrelic_haproxy_agent.yml'], 
   }
 
 }

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -1,6 +1,25 @@
 # Install the newrelic haproxy agent
 # Example:
-# 
+# class profiles::newrelic::haproxy_plugin {
+#
+#  $license_key    = hiera('newrelic_license_key')
+#  $haproxy_agents  = {
+#    'qa_haproxy_internal' => {
+#      'uri'         => 'http://10.0.3.131:22002/;csv',
+#      'proxy'       => 'http-in',
+#      'proxy_type'  => 'FRONTEND',
+#    }
+#  }
+#
+#  class { ::newrelic_plugins::haproxy:
+#    license_key     => $license_key,
+#    haproxy_agents  => $haproxy_agents,
+#  }
+#}
+#
+# Meta
+# Author: github/malnick
+###################################################### 
 
 class newrelic_plugins::haproxy (
   

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -51,6 +51,8 @@ class newrelic_plugins::haproxy (
   }
 
   else {  
+    # If we're using the configured install, ensure haproxy_agents is a hash
+    validate_hash($haproxy_agents, 'You must pass a hash to $haproxy_agents')
     # Configure the yaml file - requires that haproxy_agents hash is not empty
     file { '/etc/newrelic/newrelic_haproxy_agent.yml':
       ensure    => file,

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -52,7 +52,7 @@ class newrelic_plugins::haproxy (
 
   else {  
     # If we're using the configured install, ensure haproxy_agents is a hash
-    validate_hash($haproxy_agents, 'You must pass a hash to $haproxy_agents')
+    validate_hash($haproxy_agents)
     # Configure the yaml file - requires that haproxy_agents hash is not empty
     file { '/etc/newrelic/newrelic_haproxy_agent.yml':
       ensure    => file,

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -6,7 +6,7 @@ class newrelic_plugins::haproxy (
   
   $license_key,
   $base_install   = false,
-  $haproxy_agents = {},
+  $haproxy_agents = undef,
 
 ){
 

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -51,7 +51,7 @@ class newrelic_plugins::haproxy (
   service { 'newrelic_haproxy_plugin':
     ensure    => running,
     enable    => true,
-    subscribe => File['newrelic_haproxy_agent_init','/etc/newrelic/newrelic/newrelic_haproxy_agent.yml'], 
+    subscribe => File['newrelic_haproxy_agent_init','/etc/newrelic/newrelic_haproxy_agent.yml'], 
   }
 
 }

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -27,9 +27,9 @@ class newrelic_plugins::haproxy (
   }
 
   exec {'newrelic_haproxy_agent_config':
-    command => '/usr/local/bin/newrelic_haproxy_agent install',
-    require => Package['bundler','newrelic_plugin','newrelic_haproxy_agent'],
-    create  => '/etc/newrelic/newrelic_haproxy_agent.yml',
+    command  => '/usr/local/bin/newrelic_haproxy_agent install',
+    require  => Package['bundler','newrelic_plugin','newrelic_haproxy_agent'],
+    creates  => '/etc/newrelic/newrelic_haproxy_agent.yml',
   }
 
   service { 'newrelic_haproxy_agent':

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -6,7 +6,7 @@ class newrelic_plugins::haproxy (
   
   $license_key,
   $base_install   = false,
-  $haproxy_agent  = {},
+  $haproxy_agents = {},
 
 ){
 

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -1,0 +1,19 @@
+class newrelic_plugins::haproxy (
+  
+  $license_key,
+
+){
+
+  package { 'make':
+    ensure => present,
+  }
+
+  package { 'newrelic_haproxy_agent':
+    ensure    => present,
+    provider  => 'gem',
+    require   => Package['make'],
+  }
+
+
+
+}

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -29,6 +29,9 @@ class newrelic_plugins::haproxy (
   file { 'newrelic_haproxy_agent_init':
     ensure  => file,
     path    => '/etc/init.d/newrelic_haproxy_plugin',
+    mode    => '0755',
+    user    => 'root',
+    group   => 'root',
     content => template('newrelic_plugins/haproxy/newrelic_haproxy_plugin.erb'),
   }
 

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -28,8 +28,8 @@ class newrelic_plugins::haproxy (
 
   file { 'newrelic_haproxy_agent_init':
     ensure  => file,
-    path    => '/etc/init.d/newrelic_haproxy_agent',
-    content => template('haproxy/newrelic_haproxy_agent.erb'),
+    path    => '/etc/init.d/newrelic_haproxy_plugin',
+    content => template('haproxy/newrelic_haproxy_plugin.erb'),
   }
 
   exec {'newrelic_haproxy_agent_config':
@@ -38,7 +38,7 @@ class newrelic_plugins::haproxy (
     creates  => '/etc/newrelic/newrelic_haproxy_agent.yml',
   }
 
-  service { 'newrelic_haproxy_agent':
+  service { 'newrelic_haproxy_plugin':
     ensure    => running,
     enable    => true,
     subscribe => File['newrelic_haproxy_agent_init'], 

--- a/manifests/haproxy.pp
+++ b/manifests/haproxy.pp
@@ -1,6 +1,12 @@
+# Install the newrelic haproxy agent
+# Example:
+# 
+
 class newrelic_plugins::haproxy (
   
   $license_key,
+  $base_install   = false,
+  $haproxy_agent  = {},
 
 ){
 
@@ -41,6 +47,7 @@ class newrelic_plugins::haproxy (
     creates  => '/etc/newrelic/newrelic_haproxy_agent.yml',
   }
 
+  # Configure the yaml file
   service { 'newrelic_haproxy_plugin':
     ensure    => running,
     enable    => true,

--- a/templates/haproxy/newrelic_haproxy_agent.yml.erb
+++ b/templates/haproxy/newrelic_haproxy_agent.yml.erb
@@ -15,10 +15,10 @@ newrelic:
 # Agent Configuration:
 #
 agents:
-<% @haproxy_agents.each do |a| %>
+<% @haproxy_agents.each do |a,b| -%>
   <%= a %>:
     # URI of the haproxy CSV stats url. See the 'CSV Export' link on your haproxy stats page (example stats page: http://demo.1wt.eu/).
-    uri: <%= a['uri'] %> 
+    uri: <%= b['uri'] %> 
     # The name of the proxy to monitor. Proxies are typically listed in the haproxy.cfg file.
     proxy: <%= a['proxy'] %> #http-in
     # If multiple proxies have the same name, specify which proxy you want to monitor (ex: 'frontend' or 'backend')."

--- a/templates/haproxy/newrelic_haproxy_agent.yml.erb
+++ b/templates/haproxy/newrelic_haproxy_agent.yml.erb
@@ -1,0 +1,32 @@
+##########################
+# Managed by Your Mother #
+##########################
+newrelic:
+  #
+  # Update with your New Relic account license key:
+  #
+  license_key: <%= @license_key %>
+  #
+  # Set to '1' for verbose output, remove for normal output.
+  # All output goes to stdout/stderr.
+  #
+  verbose: 0
+#
+# Agent Configuration:
+#
+agents:
+<% @haproxy_agents.each do |a| %>
+  <%= a %>:
+    # URI of the haproxy CSV stats url. See the 'CSV Export' link on your haproxy stats page (example stats page: http://demo.1wt.eu/).
+    uri: <%= a['uri'] %> 
+    # The name of the proxy to monitor. Proxies are typically listed in the haproxy.cfg file.
+    proxy: <%= a['proxy'] %> #http-in
+    # If multiple proxies have the same name, specify which proxy you want to monitor (ex: 'frontend' or 'backend')."
+    proxy_type: <%= a['proxy_type'] %> #FRONTEND
+    # If protected under basic authentication provide the user name
+<% if @user %>
+    user: <%= a['user'] %>
+    # If protected under basic authentication provide the password.
+    password: <%= a['password'] %> 
+<% end %>
+<% end %>

--- a/templates/haproxy/newrelic_haproxy_agent.yml.erb
+++ b/templates/haproxy/newrelic_haproxy_agent.yml.erb
@@ -20,13 +20,13 @@ agents:
     # URI of the haproxy CSV stats url. See the 'CSV Export' link on your haproxy stats page (example stats page: http://demo.1wt.eu/).
     uri: <%= b['uri'] %> 
     # The name of the proxy to monitor. Proxies are typically listed in the haproxy.cfg file.
-    proxy: <%= a['proxy'] %> #http-in
+    proxy: <%= b['proxy'] %> #http-in
     # If multiple proxies have the same name, specify which proxy you want to monitor (ex: 'frontend' or 'backend')."
-    proxy_type: <%= a['proxy_type'] %> #FRONTEND
+    proxy_type: <%= b['proxy_type'] %> #FRONTEND
     # If protected under basic authentication provide the user name
-<% if @user %>
-    user: <%= a['user'] %>
+<% if b['user'] %>
+    user: <%= b['user'] %>
     # If protected under basic authentication provide the password.
-    password: <%= a['password'] %> 
+    password: <%= b['password'] %> 
 <% end %>
 <% end %>

--- a/templates/haproxy/newrelic_haproxy_agent.yml.erb
+++ b/templates/haproxy/newrelic_haproxy_agent.yml.erb
@@ -15,6 +15,7 @@ newrelic:
 # Agent Configuration:
 #
 agents:
+<% if @haproxy_agents -%>
 <% @haproxy_agents.each do |a,b| -%>
   <%= a %>:
     # URI of the haproxy CSV stats url. See the 'CSV Export' link on your haproxy stats page (example stats page: http://demo.1wt.eu/).
@@ -29,4 +30,7 @@ agents:
     # If protected under basic authentication provide the password.
     password: <%= b['password'] %> 
 <% end -%>
+<% end -%>
+<% else %>
+<% abort "Must pass haproxy_agents hash" %>
 <% end -%>

--- a/templates/haproxy/newrelic_haproxy_agent.yml.erb
+++ b/templates/haproxy/newrelic_haproxy_agent.yml.erb
@@ -15,7 +15,7 @@ newrelic:
 # Agent Configuration:
 #
 agents:
-<% @haproxy_agents.each do |a,b| -%>
+<% @haproxy_agents.each do |a,b| %>
   <%= a %>:
     # URI of the haproxy CSV stats url. See the 'CSV Export' link on your haproxy stats page (example stats page: http://demo.1wt.eu/).
     uri: <%= b['uri'] %> 

--- a/templates/haproxy/newrelic_haproxy_agent.yml.erb
+++ b/templates/haproxy/newrelic_haproxy_agent.yml.erb
@@ -15,7 +15,7 @@ newrelic:
 # Agent Configuration:
 #
 agents:
-<% @haproxy_agents.each do |a,b| %>
+<% @haproxy_agents.each do |a,b| -%>
   <%= a %>:
     # URI of the haproxy CSV stats url. See the 'CSV Export' link on your haproxy stats page (example stats page: http://demo.1wt.eu/).
     uri: <%= b['uri'] %> 
@@ -24,9 +24,9 @@ agents:
     # If multiple proxies have the same name, specify which proxy you want to monitor (ex: 'frontend' or 'backend')."
     proxy_type: <%= b['proxy_type'] %> #FRONTEND
     # If protected under basic authentication provide the user name
-<% if b['user'] %>
+<% if b['user'] -%>
     user: <%= b['user'] %>
     # If protected under basic authentication provide the password.
     password: <%= b['password'] %> 
-<% end %>
-<% end %>
+<% end -%>
+<% end -%>

--- a/templates/haproxy/newrelic_haproxy_plugin.erb
+++ b/templates/haproxy/newrelic_haproxy_plugin.erb
@@ -1,0 +1,78 @@
+#!/bin/sh
+
+### BEGIN INIT INFO
+# Required-Start:    $syslog $remote_fs
+# Required-Stop:     $syslog $remote_fs
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: New Relic <%= @plugin_name %> Plugin
+# Description:       Controls the New Relic <%= @plugin_name %> Plugin
+### END INIT INFO
+
+DESC="New Relic <%= @plugin_name %> Plugin Daemon"
+DAEMONDIR=/var/log/
+PIDFILE=/var/run/$NAME.pid
+
+get_pid() {
+  cat "$PIDFILE"
+}
+
+is_running() {
+  [ -f "$PIDFILE" ] && ps `get_pid` > /dev/null 2>&1
+}
+
+start() {
+  if is_running; then
+    echo "Already Started $NAME"
+  else
+    echo "Starting $NAME"
+    cd $DAEMONDIR
+    touch $PIDFILE 
+    /usr/lcoal/bin/newrelic_haproxy_agent run >> $DAEMONDIR/newrelic_haproxy_agent.log 2>&1 & echo \$! > $PIDFILE"
+  fi
+}
+
+status() {
+  if is_running; then
+    echo "$NAME $VERSION is running"
+  else
+    echo "$NAME $VERSION is stopped"
+    exit 1
+  fi
+}
+
+stop() {
+  if is_running; then
+    echo "Stopping $NAME"
+    kill `get_pid`
+  else
+    echo "$NAME is not running"
+  fi
+}
+
+restart() {
+  stop
+  sleep 1
+  start
+}
+
+case "${1}" in
+  start)
+    start
+    ;;
+  stop)
+    stop
+    ;;
+  status)
+    status
+    ;;
+  restart)
+    restart
+    ;;
+  *)
+    echo "Usage: ${0} {start|stop|restart|status}"
+    exit 1
+    ;;
+esac
+
+exit 0

--- a/templates/haproxy/newrelic_haproxy_plugin.erb
+++ b/templates/haproxy/newrelic_haproxy_plugin.erb
@@ -28,7 +28,7 @@ start() {
     echo "Starting $NAME"
     cd $DAEMONDIR
     touch $PIDFILE 
-    newrelic_haproxy_agent run >> $DAEMONDIR/newrelic_haproxy_agent.log 2>&1 & echo \$! > $PIDFILE"
+    newrelic_haproxy_agent run >> $DAEMONDIR/newrelic_haproxy_agent.log 2>&1 & echo \$! > $PIDFILE
   fi
 }
 

--- a/templates/haproxy/newrelic_haproxy_plugin.erb
+++ b/templates/haproxy/newrelic_haproxy_plugin.erb
@@ -28,7 +28,7 @@ start() {
     echo "Starting $NAME"
     cd $DAEMONDIR
     touch $PIDFILE 
-    /usr/lcoal/bin/newrelic_haproxy_agent run >> $DAEMONDIR/newrelic_haproxy_agent.log 2>&1 & echo \$! > $PIDFILE"
+    newrelic_haproxy_agent run >> $DAEMONDIR/newrelic_haproxy_agent.log 2>&1 & echo \$! > $PIDFILE"
   fi
 }
 


### PR DESCRIPTION
The haproxy plugin for newrelic. This module installs the newrelic_haproxy_agent gem, configures an init script and manages the plugin as a service. 