### PR TITLE
Fixed non qualified class reference in inherits

### DIFF
--- a/manifests/aws_cloudwatch.pp
+++ b/manifests/aws_cloudwatch.pp
@@ -53,7 +53,7 @@ class newrelic_plugins::aws_cloudwatch (
     $agents,
     $version = $newrelic_plugins::params::aws_cloudwatch_version,
     $regions = [],
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/example.pp
+++ b/manifests/example.pp
@@ -34,7 +34,7 @@ class newrelic_plugins::example (
     $install_path,
     $user,
     $version = $newrelic_plugins::params::example_version,
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/f5.pp
+++ b/manifests/f5.pp
@@ -46,7 +46,7 @@ class newrelic_plugins::f5 (
     $user,
     $version = $newrelic_plugins::params::f5_version,
     $agents,
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 #   class { 'newrelic_plugins': }
 #
 class newrelic_plugins(
-) inherits params {
+) inherits newrelic_plugins::params {
 
 }
 

--- a/manifests/memcached_java.pp
+++ b/manifests/memcached_java.pp
@@ -68,7 +68,7 @@ class newrelic_plugins::memcached_java (
     $version = $newrelic_plugins::params::memcached_java_version,
     $servers,
     $java_options = $newrelic_plugins::params::memcached_java_options,
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/memcached_ruby.pp
+++ b/manifests/memcached_ruby.pp
@@ -45,7 +45,7 @@ class newrelic_plugins::memcached_ruby (
     $user,
     $version = $newrelic_plugins::params::memcached_ruby_version,
     $agents,
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/mysql.pp
+++ b/manifests/mysql.pp
@@ -91,7 +91,7 @@ class newrelic_plugins::mysql (
     $plugin_template = 'newrelic_plugins/mysql/plugin.json.erb',
     $service_enable = true,
     $service_ensure = running,
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/rackspace_load_balancers.pp
+++ b/manifests/rackspace_load_balancers.pp
@@ -48,7 +48,7 @@ class newrelic_plugins::rackspace_load_balancers (
     $api_key,
     $region,
     $version = $newrelic_plugins::params::rackspace_load_balancers_version,
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/wikipedia_example_java.pp
+++ b/manifests/wikipedia_example_java.pp
@@ -35,7 +35,7 @@ class newrelic_plugins::wikipedia_example_java (
     $install_path,
     $user,
     $version = $newrelic_plugins::params::wikipedia_example_java_version
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 

--- a/manifests/wikipedia_example_ruby.pp
+++ b/manifests/wikipedia_example_ruby.pp
@@ -34,7 +34,7 @@ class newrelic_plugins::wikipedia_example_ruby (
     $install_path,
     $user,
     $version = $newrelic_plugins::params::wikipedia_example_ruby_version,
-) inherits params {
+) inherits newrelic_plugins::params {
 
   include stdlib
 


### PR DESCRIPTION
In puppet 4 this will fail:

```
class newrelic_plugins(
) inherits params {

}
```

`params` should be referenced as `newrelic_plugins::params`
