### PR TITLE
On Debian and Ubuntu libxslt-dev is a virtual package

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class newrelic_plugins::params {
 
   # nokogiri dependencies
   if $::osfamily == 'Debian' {
-    $nokogiri_packages = ['libxml2-dev', 'libxslt-dev']
+    $nokogiri_packages = ['libxml2-dev', 'libxslt1-dev']
   }
   else {
     $nokogiri_packages = ['libxml2', 'libxml2-devel', 'libxslt', 'libxslt-devel']


### PR DESCRIPTION
Puppet handling of virtual packages is not optimal: on each run we get:
Notice: /Stage[main]/Newrelic_plugins::Aws_cloudwatch/Package[libxslt-dev]/ensure: ensure changed 'purged' to 'present'
because libxslt-dev is not found as installed, and when we install it, being a virtual package, it installs libxslt1-dev
So better to use directly libxslt1-dev for idempotency.

References:
https://packages.debian.org/sid/libxslt-dev
http://packages.ubuntu.com/precise/libxslt-dev