### PR TITLE
no sudo during bundle install and other minor fixes

### DIFF
--- a/manifests/aws_cloudwatch.pp
+++ b/manifests/aws_cloudwatch.pp
@@ -29,6 +29,9 @@
 #                    provided, the plugin will default to all available
 #                    regions.
 #
+# $install_nokogiri_packages:: Install nokogiri packages. Defaults to
+#                              `false`.
+#
 # == Requires:
 #
 #   puppetlabs/stdlib
@@ -51,8 +54,9 @@ class newrelic_plugins::aws_cloudwatch (
     $aws_access_key,
     $aws_secret_key,
     $agents,
-    $version = $newrelic_plugins::params::aws_cloudwatch_version,
-    $regions = [],
+    $version                   = $newrelic_plugins::params::aws_cloudwatch_version,
+    $regions                   = [],
+    $install_nokogiri_packages = false,
 ) inherits params {
 
   include stdlib
@@ -75,9 +79,11 @@ class newrelic_plugins::aws_cloudwatch (
   }
 
   # nokogiri packages
-  package { $newrelic_plugins::params::nokogiri_packages:
-    ensure => present,
-    before => Newrelic_plugins::Resource::Install_plugin['newrelic_aws_cloudwatch_plugin'] # for puppet 2.x support
+  if $install_nokogiri_packages {
+    package { $newrelic_plugins::params::nokogiri_packages:
+      ensure => present,
+      before => Newrelic_plugins::Resource::Install_plugin['newrelic_aws_cloudwatch_plugin'] # for puppet 2.x support
+    }
   }
 
   $plugin_path = "${install_path}/newrelic_aws_cloudwatch_plugin"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class newrelic_plugins::params {
 
   # nokogiri dependencies
   if $::osfamily == 'Debian' {
-    $nokogiri_packages = ['libxml2-dev', 'libxslt-dev']
+    $nokogiri_packages = ['libxml2-dev', 'libxslt1-dev']
   }
   else {
     $nokogiri_packages = ['libxml2', 'libxml2-devel', 'libxslt', 'libxslt-devel']

--- a/manifests/resource/bundle_install.pp
+++ b/manifests/resource/bundle_install.pp
@@ -4,7 +4,8 @@ define newrelic_plugins::resource::bundle_install ($plugin_path, $user) {
     # install bundler gem
     package { 'bundler' :
       ensure   => present,
-      provider => gem
+      provider => gem,
+      notify   => Exec["${name}: bundle install"],
     }
   }
 
@@ -14,6 +15,7 @@ define newrelic_plugins::resource::bundle_install ($plugin_path, $user) {
     command     => "bundle install",
     cwd         => $plugin_path,
     require     => Package['bundler'],
-    user        => $user
+    user        => $user,
+    refreshonly => true,
   }
 }

--- a/manifests/resource/bundle_install.pp
+++ b/manifests/resource/bundle_install.pp
@@ -11,7 +11,7 @@ define newrelic_plugins::resource::bundle_install ($plugin_path, $user) {
   # bundle install
   exec { "${name}: bundle install":
     path        => $::path,
-    command     => "sudo -u ${user} bundle install",
+    command     => "bundle install",
     cwd         => $plugin_path,
     require     => Package['bundler'],
     user        => $user


### PR DESCRIPTION
* do not use sudo during bundle install
* execute `bundle install` only when bundler is installed initially
* use libxslt1-dev package in debian
* parameterize nokogiri package install