### PR TITLE
Adding optional manage_packages to AWSCW and RSLB packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ An example of using the AWS Cloudwatch and MySQL plugins with two classes. See t
 
 `regions` - _(optional)_ Array of AWS Cloudwatch regions. e.g. `us-east-1`. Defaults to all available regions
 
+`manage_packages` - _(optional)_ Allow package to manage its own dependencies
 ####Class
 
     class { 'newrelic_plugins::aws_cloudwatch':
@@ -325,6 +326,8 @@ For additional info, see https://github.com/newrelic-platform/newrelic_mysql_jav
 `region` - _(required)_ Region for Rackspace Load Balancers. Valid regions are: `ord`, `dfw`, and `lon`.
 
 `version` - _(optional)_ Plugin version. Defaults to latest release version
+
+`manage_packages` - _(optional)_ Allow package to manage its own dependencies
 
 ####Class
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ An example of using the AWS Cloudwatch and MySQL plugins with two classes. See t
 `regions` - _(optional)_ Array of AWS Cloudwatch regions. e.g. `us-east-1`. Defaults to all available regions
 
 `manage_packages` - _(optional)_ Allow package to manage its own dependencies
+
 ####Class
 
     class { 'newrelic_plugins::aws_cloudwatch':

--- a/manifests/aws_cloudwatch.pp
+++ b/manifests/aws_cloudwatch.pp
@@ -29,6 +29,8 @@
 #                    provided, the plugin will default to all available
 #                    regions.
 #
+# $manage_packages:: Allow package to manage its own dependencies
+#
 # == Requires:
 #
 #   puppetlabs/stdlib
@@ -53,6 +55,7 @@ class newrelic_plugins::aws_cloudwatch (
     $agents,
     $version = $newrelic_plugins::params::aws_cloudwatch_version,
     $regions = [],
+    $manage_packages = true
 ) inherits params {
 
   include stdlib
@@ -75,9 +78,11 @@ class newrelic_plugins::aws_cloudwatch (
   }
 
   # nokogiri packages
-  package { $newrelic_plugins::params::nokogiri_packages:
-    ensure => present,
-    before => Newrelic_plugins::Resource::Install_plugin['newrelic_aws_cloudwatch_plugin'] # for puppet 2.x support
+  if $manage_packages {
+    package { $newrelic_plugins::params::nokogiri_packages:
+      ensure => present,
+      before => Newrelic_plugins::Resource::Install_plugin['newrelic_aws_cloudwatch_plugin'] # for puppet 2.x support
+    }
   }
 
   $plugin_path = "${install_path}/newrelic_aws_cloudwatch_plugin"

--- a/manifests/rackspace_load_balancers.pp
+++ b/manifests/rackspace_load_balancers.pp
@@ -24,6 +24,7 @@
 # $region::          Region for Rackspace Load Balancers. Valid regions are:
 #                    'ord', 'dfw', and 'lon'.
 #
+# $manage_packages:: Allow package to manage its own dependencies
 #
 # == Requires:
 #
@@ -48,6 +49,7 @@ class newrelic_plugins::rackspace_load_balancers (
     $api_key,
     $region,
     $version = $newrelic_plugins::params::rackspace_load_balancers_version,
+    $manage_packages = true
 ) inherits params {
 
   include stdlib
@@ -69,9 +71,11 @@ class newrelic_plugins::rackspace_load_balancers (
   }
 
   # nokogiri packages
-  package { $newrelic_plugins::params::nokogiri_packages:
-    ensure => present,
-    before => Newrelic_plugins::Resource::Install_plugin['newrelic_rackspace_load_balancers_plugin'] # for puppet 2.x support
+  if $manage_packages {
+    package { $newrelic_plugins::params::nokogiri_packages:
+      ensure => present,
+      before => Newrelic_plugins::Resource::Install_plugin['newrelic_rackspace_load_balancers_plugin'] # for puppet 2.x support
+    }
   }
 
   $plugin_path = "${install_path}/newrelic_rackspace_load_balancers_plugin"


### PR DESCRIPTION
The package currently causes conflicts in package management due to our own stack setup to control what is installed.

This PR allows for the NR puppet package to allow an extra param to enable / disable management of packages that related to the stack externally.